### PR TITLE
Add custom buffer constructor

### DIFF
--- a/src/count_min_sketch.c
+++ b/src/count_min_sketch.c
@@ -358,6 +358,7 @@ static void __read_from_file(CountMinSketch* cms, FILE *fp, short on_disk, const
     rewind(fp);
     size_t length = cms->width * cms->depth;
     if (on_disk == 0) {
+        cms->managed = 1;
         cms->bins = (int32_t*)malloc(length * sizeof(int32_t));
         size_t read = fread(cms->bins, sizeof(int32_t), length, fp);
         if (read != length) {

--- a/src/count_min_sketch.h
+++ b/src/count_min_sketch.h
@@ -42,6 +42,7 @@ typedef struct {
     double error_rate;
     cms_hash_function hash_function;
     int32_t* bins;
+    uint32_t managed: 1;
 }  CountMinSketch, count_min_sketch;
 
 
@@ -67,6 +68,32 @@ static __inline__ int cms_init(CountMinSketch* cms, unsigned int width, unsigned
 int cms_init_optimal_alt(CountMinSketch* cms, double error_rate, double confidence, cms_hash_function hash_function);
 static __inline__ int cms_init_optimal(CountMinSketch* cms, float error_rate, float confidence) {
     return cms_init_optimal_alt(cms, error_rate, confidence, NULL);
+}
+
+/*  Initialize the count-min sketch based on user defined width and depth
+    This version takes a custom buffer, which **must** be of at least
+    sizeof(int32_t) * width * depth size
+    width and depth must be positive integers
+
+    Passing to cms_destroy() is safe; the buffer remains untouched
+    You must manage your own buffer as required
+    For advanced users only
+
+    Returns:
+        CMS_SUCCESS
+        CMS_ERROR   -   when width or depth are 0 or negative */
+int cms_init_custom_buffer_alt(
+    CountMinSketch* cms,
+    unsigned int width,
+    unsigned int depth,
+    int32_t* buffer,
+    cms_hash_function hash_function);
+static __inline__ int cms_init_custom_buffer(
+    CountMinSketch* cms,
+    unsigned int width,
+    unsigned int depth,
+    int32_t* buffer) {
+    return cms_init_custom_buffer_alt(cms, width, depth, buffer, NULL);
 }
 
 

--- a/tests/count_min_sketch_test.c
+++ b/tests/count_min_sketch_test.c
@@ -215,6 +215,32 @@ int main(int argc, char** argv) {
 
     cms_destroy(&cms);
 
+    printf("Count-Min Sketch: setup using custom buffer (unmanaged): ");
+    int32_t buffer[2000 * 17] = { 0 };
+    cms_init_custom_buffer(&cms, 2000, 17, buffer);
+    if (!cms.managed) {
+        success_or_failure(0);
+    } else {
+        success_or_failure(1);
+    }
+
+    printf("Count-Min Sketch: set up width and depth: ");
+    if (cms.width == 2000 && cms.depth == 17) {
+        success_or_failure(0);
+    } else {
+        success_or_failure(1);
+    }
+
+    printf("Count-Min Sketch: buffer is correct: ");
+    if (cms.bins == buffer) {
+        success_or_failure(0);
+    } else {
+        success_or_failure(1);
+    }
+
+    // If free() is called on buffer[][], this should segfault
+    cms_destroy(&cms);
+
     printf("Count-Min Sketch: import: ");
     result = 0;
     result = cms_import(&cms, "./dist/test_export.cms");


### PR DESCRIPTION
Implements the ability to pass a custom memory buffer for use in the CMS struct.

Could be useful for e.g. mmap'd buffers for graceful restart, shared memory buffers for syncing between processes, etc.

Has appropriate documentation/warnings